### PR TITLE
Ignore errors when parsing log files

### DIFF
--- a/jamjar/parsers/_dc.py
+++ b/jamjar/parsers/_dc.py
@@ -27,7 +27,7 @@ class DCParser(BaseParser):
 
     def parse_logfile(self, filename):
         """Parse '-dc' debug output from the file at the given path."""
-        with open(filename) as f:
+        with open(filename, errors="ignore") as f:
             self._parse(f)
 
     def _parse(self, lines):

--- a/jamjar/parsers/_dd.py
+++ b/jamjar/parsers/_dd.py
@@ -27,7 +27,7 @@ class DDParser(BaseParser):
         Depends x:y
         Includes x:y """
 
-        with open(filename) as f:
+        with open(filename, errors="ignore") as f:
             for line in f:
                 # Depending on the first word, add the relevant information to the database
                 #

--- a/jamjar/parsers/_dm.py
+++ b/jamjar/parsers/_dm.py
@@ -48,7 +48,7 @@ class DMParser(BaseParser):
            the DB"""
         # Open the file
         try:
-            f = open(filename)
+            f = open(filename, errors="ignore")
         except:
             # The file cannot be opened.
             print("Unable to open file %s" % filename)


### PR DESCRIPTION
Ignore errors when parsing log files, so that invalid UTC characters don't result in exception.
